### PR TITLE
Add a list of citable objects to frontpage

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,6 +159,12 @@
         ZuHone
     </div>
     <div align=left>
+        Citeable works related to radio-astro-tools include:
+        <ul>
+            <li> <a href="http://adsabs.harvard.edu/abs/2015ASPC..499..363G">Radio Astronomy Tools in Python: Spectral-cube, pvextractor, and more</a>, a poster at the Tokyo ALMA 2014 conference
+        </ul>
+    </div>
+    <div align=left>
         This project has been partially funded from the ALMA development program funded by the NSF.
     </div>
 


### PR DESCRIPTION
Right now, just one entry, but we should expand this as we publish things